### PR TITLE
Issue#204 shapefile handler does not accept cpg and cst files

### DIFF
--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -155,7 +155,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
 
         if not files.get("cpg_file"):
             # set a default
-            encoding = "UTF-8"
+            encoding = "ISO-8859-1"
             # GeoServer exports cst-file
             if files.get("cst_file"):
                 encoding_file = files.get("cst_file")
@@ -164,7 +164,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
             try:
                 codecs.lookup(encoding)
             except LookupError as e:
-                encoding = "UTF-8"
+                encoding = "ISO-8859-1"
                 logger.error(f"Invalid encoding! Use the default: {encoding} {e}")
 
         additional_options = (

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -48,7 +48,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
             "format": "vector",
             "ext": ["shp"],
             "requires": ["shp", "prj", "dbf", "shx"],
-            "optional": ["xml", "sld"],
+            "optional": ["xml", "sld", "cpg"],
         }
 
     @staticmethod

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -153,19 +153,16 @@ class ShapeFileHandler(BaseVectorFileHandler):
         layers = ogr.Open(files.get("base_file"))
         layer = layers.GetLayer(original_name)
 
-        if not files.get("cpg_file"):
-            # set a default
-            encoding = "ISO-8859-1"
+        if not files.get("cpg_file") and files.get("cst_file"):
             # GeoServer exports cst-file
-            if files.get("cst_file"):
-                encoding_file = files.get("cst_file")
-                with open(encoding_file) as f:
-                    encoding = f.read()
+            encoding_file = files.get("cst_file")
+            with open(encoding_file) as f:
+                encoding = f.read()
             try:
                 codecs.lookup(encoding)
             except LookupError as e:
-                encoding = "ISO-8859-1"
-                logger.error(f"Invalid encoding! Use the default: {encoding} {e}")
+                encoding = None
+                logger.error(f"Will ignore invalid encoding: {e}")
 
         additional_options = (
             " -nlt PROMOTE_TO_MULTI"


### PR DESCRIPTION
Allows `cpg`-files when uploading shapefiles. If not present, tries to read encoding from `cst` file, or uses default encoding `ISO-8859-1`. 

`cpg` file is handled by GDAL, while default and `cst` content is read and set on `ENCODING` parameter. 

related issue #204