### PR TITLE
Fix error in rollback action

### DIFF
--- a/importer/handlers/common/raster.py
+++ b/importer/handlers/common/raster.py
@@ -480,6 +480,8 @@ class BaseRasterFileHandler(BaseHandler):
         self, exec_id, rollback_from_step, action_to_rollback, *args, **kwargs
     ):
         steps = self.ACTIONS.get(action_to_rollback)
+        if rollback_from_step not in steps:
+            return        
         step_index = steps.index(rollback_from_step)
         # the start_import, start_copy etc.. dont do anything as step, is just the start
         # so there is nothing to rollback

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -758,6 +758,9 @@ class BaseVectorFileHandler(BaseHandler):
         self, exec_id, rollback_from_step, action_to_rollback, *args, **kwargs
     ):
         steps = self.ACTIONS.get(action_to_rollback)
+        if rollback_from_step not in steps:
+            logger.info("Step not found, skipping")
+            return        
         step_index = steps.index(rollback_from_step)
         # the start_import, start_copy etc.. dont do anything as step, is just the start
         # so there is nothing to rollback


### PR DESCRIPTION
Sometimes it happen that the importer raise the following error and cover the real one:

```
importer.api.exception.StartImportException: tuple.index(x): x not in tuple. Request: <request_id>
```

This is done because the `importer.rollback_function` is not found in the `IMPORT` action and it mainly happen if celery retry to ack the massage during debug purposes