### PR TITLE
Return detail_url for SLD and XML and prepare for the new input params

### DIFF
--- a/importer/api/serializer.py
+++ b/importer/api/serializer.py
@@ -15,6 +15,7 @@ class ImporterSerializer(DynamicModelSerializer):
             "store_spatial_files",
             "overwrite_existing_layer",
             "skip_existing_layers",
+            "source"
         )
 
     base_file = serializers.FileField()
@@ -23,3 +24,4 @@ class ImporterSerializer(DynamicModelSerializer):
     store_spatial_files = serializers.BooleanField(required=False, default=True)
     overwrite_existing_layer = serializers.BooleanField(required=False, default=False)
     skip_existing_layers = serializers.BooleanField(required=False, default=False)
+    source = serializers.CharField(required=False, default='upload')

--- a/importer/api/views.py
+++ b/importer/api/views.py
@@ -148,7 +148,7 @@ class ImporterViewSet(DynamicModelViewSet):
                     legacy_upload_name=_file.name,
                     action=action,
                     name=_file.name,
-                    source="upload",
+                    source=extracted_params.get('source'),
                 )
 
                 sig = import_orchestrator.s(

--- a/importer/handlers/common/metadata.py
+++ b/importer/handlers/common/metadata.py
@@ -50,6 +50,7 @@ class MetadataFileHandler(BaseHandler):
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
             "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
+            "source": _data.pop("source", "True"),
         }, _data
 
     @staticmethod

--- a/importer/handlers/common/metadata.py
+++ b/importer/handlers/common/metadata.py
@@ -1,6 +1,7 @@
 import logging
 from geonode.resource.enumerator import ExecutionRequestAction as exa
 from importer.handlers.base import BaseHandler
+from importer.models import ResourceHandlerInfo
 from importer.handlers.xml.serializer import MetadataFileSerializer
 from importer.utils import ImporterRequestAction as ira
 from importer.orchestrator import orchestrator
@@ -53,18 +54,39 @@ class MetadataFileHandler(BaseHandler):
 
     @staticmethod
     def perform_last_step(execution_id):
-        pass
+        _exec = orchestrator.get_execution_object(execution_id)
+        
+        _exec.output_params.update(
+            **{
+                "detail_url": [
+                    x.resource.detail_url
+                    for x in ResourceHandlerInfo.objects.filter(execution_request=_exec)
+                ]
+            }
+        )
+        _exec.save()
 
     def import_resource(self, files: dict, execution_id: str, **kwargs):
         _exec = orchestrator.get_execution_object(execution_id)
         # getting the dataset
         alternate = _exec.input_params.get("dataset_title")
-        dataset = get_object_or_404(Dataset, alternate=alternate)
+        resource_id = _exec.input_params.get("resource_id")
+        if resource_id:
+            dataset = get_object_or_404(Dataset, pk=resource_id)
+        elif alternate:
+            dataset = get_object_or_404(Dataset, alternate=alternate)
 
         # retrieving the handler used for the dataset
         original_handler = orchestrator.load_handler(
             dataset.resourcehandlerinfo_set.first().handler_module_path
         )()
+        
+        ResourceHandlerInfo.objects.create(
+            handler_module_path=dataset.resourcehandlerinfo_set.first().handler_module_path,
+            resource=dataset,
+            execution_request=_exec,
+            kwargs=kwargs.get("kwargs", {}) or kwargs,
+        )
 
         self.handle_metadata_resource(_exec, dataset, original_handler)
 

--- a/importer/handlers/common/raster.py
+++ b/importer/handlers/common/raster.py
@@ -102,6 +102,7 @@ class BaseRasterFileHandler(BaseHandler):
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
             "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
+            "source": _data.pop("source", "upload"),
         }, _data
 
     @staticmethod

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -112,6 +112,7 @@ class BaseVectorFileHandler(BaseHandler):
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
             "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
+            "source": _data.pop("source", "upload"),
         }, _data
 
     @staticmethod

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -91,6 +91,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
             "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
+            "source": _data.pop("source", "upload"),
         }
 
         return additional_params, _data

--- a/importer/handlers/shapefile/serializer.py
+++ b/importer/handlers/shapefile/serializer.py
@@ -18,6 +18,7 @@ class ShapeFileSerializer(DynamicModelSerializer):
             "store_spatial_files",
             "overwrite_existing_layer",
             "skip_existing_layers",
+            "source"
         )
 
     base_file = serializers.FileField()
@@ -29,3 +30,4 @@ class ShapeFileSerializer(DynamicModelSerializer):
     store_spatial_files = serializers.BooleanField(required=False, default=True)
     overwrite_existing_layer = serializers.BooleanField(required=False, default=False)
     skip_existing_layers = serializers.BooleanField(required=False, default=False)
+    source = serializers.CharField(required=False, default='upload')

--- a/importer/handlers/xml/serializer.py
+++ b/importer/handlers/xml/serializer.py
@@ -8,7 +8,8 @@ class MetadataFileSerializer(DynamicModelSerializer):
         ref_name = "MetadataFileSerializer"
         model = Upload
         view_name = "importer_upload"
-        fields = ("dataset_title", "base_file")
+        fields = ("dataset_title", "base_file", "source")
 
     base_file = serializers.FileField()
     dataset_title = serializers.CharField(required=True)
+    source = serializers.CharField(required=False, default='resource_file_upload')


### PR DESCRIPTION
We want to return the detail URL so that the upload pages can redirect to the dataset.
At the moment we're using `detail_title` (which is the `alternate`, actually) since the legacy forms use that, but the new UI (https://github.com/GeoNode/geonode-mapstore-client/issues/1559) will pass the resource id instead, so we want to be prepared for that.