### PR TITLE
[Fixes #255] Fix encoding for Shapefile uploads

### DIFF
--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -164,7 +164,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
         ):
             additional_options.append("-nlt PROMOTE_TO_MULTI")
         if encoding:
-            additional_options.append(f"-lco ENCODING={encoding}")
+            additional_options.append(f"--config SHAPE_ENCODING {encoding}")
 
         return (
             f"{base_command } -lco precision=no -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} "

--- a/importer/handlers/shapefile/tests.py
+++ b/importer/handlers/shapefile/tests.py
@@ -121,7 +121,7 @@ class TestShapeFileFileHandler(TestCase):
             actual = self.handler.create_ogr2ogr_command(shp_with_cst, "a", False, "a")
 
             _file.assert_called_once_with(cst_file, "r")
-            self.assertIn("ENCODING=UTF-8", actual)
+            self.assertIn("--config SHAPE_ENCODING UTF-8", actual)
 
     @patch("importer.handlers.common.vector.Popen")
     def test_import_with_ogr2ogr_without_errors_should_call_the_right_command(


### PR DESCRIPTION
Use SHAPE_ENCODING parameter to inform the ogr2ogr command of the encoding for the Shapefile so it can transform accordingly.